### PR TITLE
Add Subject.

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,0 +1,2 @@
+class Subject < ApplicationRecord
+end

--- a/db/migrate/20170728212113_create_subjects.rb
+++ b/db/migrate/20170728212113_create_subjects.rb
@@ -1,0 +1,10 @@
+class CreateSubjects < ActiveRecord::Migration[5.0]
+  def change
+    create_table :subjects do |t|
+      t.string :code
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170728212113) do
+
+  create_table "subjects", force: :cascade do |t|
+    t.string   "code"
+    t.string   "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+end


### PR DESCRIPTION
We need to store the subjects that are available. We are storing this
since we need to retrieve the course schedules via the
`term/subject/schedules` endpoint and also for future features which
will require us to list out the subjects for filtering purposes. This
commit introduces a Subject model with two attributes:

* code:string
* description:string

This is all we need for now, validations and relations will be added as
required.