### PR TITLE
Relate Term and Subject.

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,6 +1,8 @@
 class Subject < ApplicationRecord
   extend ApiHelper
 
+  has_and_belongs_to_many :terms
+
   def self.update
     subjects = get("codes/subjects")[:data]
 

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,6 +1,8 @@
 class Term < ApplicationRecord
   extend ApiHelper
 
+  has_and_belongs_to_many :subjects
+
   def self.create
     id = res[:current_term]
     listings = res[:listings][Time.current.year.to_s.to_sym]

--- a/db/migrate/20170801215502_create_table_terms_subjects.rb
+++ b/db/migrate/20170801215502_create_table_terms_subjects.rb
@@ -1,0 +1,8 @@
+class CreateTableTermsSubjects < ActiveRecord::Migration[5.0]
+  def change
+    create_table :terms_subjects, id: false do |t|
+      t.belongs_to :term, index: true
+      t.belongs_to :subject, index: true
+    end
+  end
+end

--- a/db/migrate/20170801222605_rename_terms_subjects.rb
+++ b/db/migrate/20170801222605_rename_terms_subjects.rb
@@ -1,0 +1,5 @@
+class RenameTermsSubjects < ActiveRecord::Migration[5.0]
+  def change
+    rename_table 'terms_subjects', 'subjects_terms'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170730213945) do
+ActiveRecord::Schema.define(version: 20170801222605) do
 
   create_table "subjects", force: :cascade do |t|
     t.string   "code"
     t.string   "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+  end
+
+  create_table "subjects_terms", id: false, force: :cascade do |t|
+    t.integer "term_id"
+    t.integer "subject_id"
+    t.index ["subject_id"], name: "index_subjects_terms_on_subject_id"
+    t.index ["term_id"], name: "index_subjects_terms_on_term_id"
   end
 
   create_table "terms", force: :cascade do |t|


### PR DESCRIPTION
Fixes #51.
Add a many to many relation between `terms` and `subjects`. Since I
don't need to treat the join table as a resource, a simple
`has_and_belongs_to_many` relation has been used.