### PR TITLE
Implement Subject.current_subjects

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,4 +11,11 @@ class Subject < ApplicationRecord
       find_or_create_by(code: subject[:subject], description: subject[:description])
     end
   end
+
+  def self.current_subjects
+    courses = get("terms/#{Term.current.id}/courses")[:data]
+    subject_codes = courses.map { |course| course[:subject] }.uniq
+
+    where(code: subject_codes).map(&:code)
+  end
 end

--- a/test/api_test_helper.rb
+++ b/test/api_test_helper.rb
@@ -13,6 +13,12 @@ module ApiTestHelper
       to_return(status: 200, body: stub_subject_body, headers: {})
   end
 
+  def stub_current_subjects
+    stub_request(:get, "https://api.uwaterloo.ca/v2/terms/#{Term.current.id}/courses.json?key=#{ENV['KEY']}").
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
+      to_return(status: 200, body: stub_current_subjects_body, headers: {})
+  end
+
   private
 
   def stub_header
@@ -83,6 +89,42 @@ module ApiTestHelper
           "group":"MAT"
         }
       ]
+    }.to_json
+  end
+
+  def stub_current_subjects_body
+    {
+      "data":[
+        {
+          "subject":"CS",
+          "catalog_number":"115",
+          "units":0.5,
+          "title":"Programming Racket"
+        },
+        {
+          "subject":"ACC",
+          "catalog_number":"611",
+          "units":0.5,
+          "title":"External Reporting"
+        },
+        {
+          "subject":"SYDE",
+          "catalog_number":"321",
+          "units":0.5,
+          "title":"Software Design"
+        },
+        {
+          "subject":"ACC",
+          "catalog_number":"622",
+          "units":0.5,
+          "title":"Electronic Commerce"
+        },
+        {
+          "subject":"SCI",
+          "catalog_number":"650",
+          "units":0.5,
+          "title":"Cellular Biology"
+        }]
     }.to_json
   end
 end

--- a/test/api_test_helper.rb
+++ b/test/api_test_helper.rb
@@ -33,15 +33,15 @@ module ApiTestHelper
           "2017":[
             {
               "id":1234,
-              "name":"Winter 2013"
+              "name":"Winter 2017"
             },
             {
               "id":5678,
-              "name":"Spring 2013"
+              "name":"Spring 2017"
             },
             {
               "id":9101,
-              "name":"Fall 2013"
+              "name":"Fall 2017"
             }
           ]
         }

--- a/test/fixtures/subjects.yml
+++ b/test/fixtures/subjects.yml
@@ -1,0 +1,12 @@
+cs:
+  code: 'CS'
+  description: 'Computer Science'
+
+syde:
+  code: 'SYDE'
+  description: 'Systems Design Engineering'
+  terms: fall, spring
+
+sci:
+  code: 'SCI'
+  description: 'Science'

--- a/test/fixtures/terms.yml
+++ b/test/fixtures/terms.yml
@@ -1,11 +1,8 @@
-one:
-  id: 1139
+fall:
   description: 'Fall 2017'
 
-two:
-  id: 1135
+spring:
   description: 'Spring 2017'
 
-three:
-  id: 1141
+winter:
   description: 'Winter 2018'

--- a/test/fixtures/terms.yml
+++ b/test/fixtures/terms.yml
@@ -1,8 +1,11 @@
 fall:
   description: 'Fall 2017'
+  subjects: cs, sci
 
 spring:
+  id: 1234
   description: 'Spring 2017'
+  subjects: cs, syde, sci
 
 winter:
   description: 'Winter 2018'

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -19,4 +19,10 @@ class SubjectTest < ActiveSupport::TestCase
       Subject.update
     end
   end
+
+  test "#current_subjects returns a list of subjects offered in current term" do
+    stub_current_subjects
+
+    assert_equal ['CS', 'SCI', 'SYDE'], Subject.current_subjects
+  end
 end

--- a/test/models/subject_test.rb
+++ b/test/models/subject_test.rb
@@ -7,9 +7,9 @@ class SubjectTest < ActiveSupport::TestCase
   end
 
   test "#update adds new subjects to the db" do
-    Subject.update
-
-    assert_equal 5, Subject.count
+    assert_difference 'Subject.count', 5 do
+      Subject.update
+    end
   end
 
   test '#update does nothing if no new subjects are returned by the api' do

--- a/test/models/term_test.rb
+++ b/test/models/term_test.rb
@@ -10,7 +10,7 @@ class TermTest < ActiveSupport::TestCase
       Term.create
     end
 
-    record = Term.last
+    record = Term.find(1234)
 
     assert_equal 1234, record.id
     assert_equal 'Winter 2013', record.description

--- a/test/models/term_test.rb
+++ b/test/models/term_test.rb
@@ -6,6 +6,8 @@ class TermTest < ActiveSupport::TestCase
   end
 
   test "#create creates a new record for the current term using the api" do
+    Term.destroy_all
+
     assert_difference 'Term.count' do
       Term.create
     end
@@ -13,12 +15,10 @@ class TermTest < ActiveSupport::TestCase
     record = Term.find(1234)
 
     assert_equal 1234, record.id
-    assert_equal 'Winter 2013', record.description
+    assert_equal 'Winter 2017', record.description
   end
 
   test "#current returns the record for current term" do
-    Term.create
-
     assert_equal 1234, Term.current.id
   end
 end


### PR DESCRIPTION
* Why was this change necessary?
This is a gateway commit that will later help us introduce a method in
Course to populate it with the courses that are being offered in the
current term.

* How does it address the problem?
The current_subjects method returns a list of subjects that are offered
in the current academic term. The method first retrieves a list of all
courses offered in the current term. A list of unique subject codes is
mapped from this list of courses and is then used to retrieve the
corresponding Subject records.

* Are there any side effects?
Not necessarily a side effect but more of a concern. The list returned
here is indirectly linked to the current term since we use the current
term's id to hit the endpoint. This seems okay for now however we might
need to explicitly state this in the query later on.